### PR TITLE
Add Laravel 13 support and drop PHP 8.1

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,17 +13,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2, 8.1]
-        laravel: [11.*, 10.*]
+        php: [8.4, 8.3]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
-        exclude:
-          - laravel: 11.*
-            php: 8.1
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,21 +18,21 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/database": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0",
-        "spatie/laravel-package-tools": "^1.14.1"
+        "php": "^8.2",
+        "illuminate/database": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "spatie/laravel-package-tools": "^1.16.1"
     },
     "require-dev": {
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.0",
-        "larastan/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.0|^9.0",
-        "pestphp/pest": "^2.34",
-        "pestphp/pest-plugin-arch": "^2.7",
-        "pestphp/pest-plugin-laravel": "^2.3",
-        "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.3"
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-arch": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.0",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/tenant-aware.php
+++ b/config/tenant-aware.php
@@ -1,5 +1,14 @@
 <?php
 
+use Maize\TenantAware\Actions\TenantCurrentAction;
+use Maize\TenantAware\Actions\TenantCurrentOrLandlordAction;
+use Maize\TenantAware\Actions\TenantLandlordAction;
+use Maize\TenantAware\Actions\TenantOnlyCurrentAction;
+use Maize\TenantAware\Listeners\SetTenantKey;
+use Maize\TenantAware\Scopes\ScopeOrTenantWhere;
+use Maize\TenantAware\Scopes\ScopeTenantAware;
+use Maize\TenantAware\Scopes\ScopeTenantWhere;
+
 return [
 
     'tenant' => [
@@ -39,10 +48,10 @@ return [
         */
 
         'actions' => [
-            'current' => Maize\TenantAware\Actions\TenantCurrentAction::class,
-            'landlord' => Maize\TenantAware\Actions\TenantLandlordAction::class,
-            'current_or_landlord' => Maize\TenantAware\Actions\TenantCurrentOrLandlordAction::class,
-            'only_current' => Maize\TenantAware\Actions\TenantOnlyCurrentAction::class,
+            'current' => TenantCurrentAction::class,
+            'landlord' => TenantLandlordAction::class,
+            'current_or_landlord' => TenantCurrentOrLandlordAction::class,
+            'only_current' => TenantOnlyCurrentAction::class,
         ],
 
     ],
@@ -75,7 +84,7 @@ return [
             |
             */
 
-            'creating' => Maize\TenantAware\Listeners\SetTenantKey::class,
+            'creating' => SetTenantKey::class,
         ],
     ],
 
@@ -93,7 +102,7 @@ return [
         |
         */
 
-        'apply' => Maize\TenantAware\Scopes\ScopeTenantAware::class,
+        'apply' => ScopeTenantAware::class,
 
         /*
         |--------------------------------------------------------------------------
@@ -106,9 +115,9 @@ return [
         */
 
         'methods' => [
-            Maize\TenantAware\Scopes\ScopeOrTenantWhere::class,
-            Maize\TenantAware\Scopes\ScopeTenantWhere::class,
-            Maize\TenantAware\Scopes\ScopeTenantAware::class,
+            ScopeOrTenantWhere::class,
+            ScopeTenantWhere::class,
+            ScopeTenantAware::class,
         ],
     ],
 ];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Trait Maize\\TenantAware\\BelongsToTenant is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: src/BelongsToTenant.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,4 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,13 +5,6 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <coverage>
-    <report>
-      <html outputDirectory="build/coverage"/>
-      <text outputFile="build/coverage.txt"/>
-      <clover outputFile="build/logs/clover.xml"/>
-    </report>
-  </coverage>
   <logging>
     <junit outputFile="build/report.junit.xml"/>
   </logging>

--- a/src/BelongsToTenant.php
+++ b/src/BelongsToTenant.php
@@ -10,7 +10,7 @@ trait BelongsToTenant
 {
     public static function bootBelongsToTenant(): void
     {
-        static::addGlobalScope(new TenantAwareScope());
+        static::addGlobalScope(new TenantAwareScope);
 
         static::creating(
             Config::getModelCreatingListener()

--- a/src/Scopes/ScopeOrTenantWhere.php
+++ b/src/Scopes/ScopeOrTenantWhere.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ScopeOrTenantWhere extends ScopeMethod
 {
-    public function __invoke(Builder $builder, ?Model $tenant): builder
+    public function __invoke(Builder $builder, ?Model $tenant): Builder
     {
         return $builder->orWhere(
             $this->resolveTenantForeignKeyName($builder),

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Maize\TenantAware\Actions\TenantCurrentAction;
 use Maize\TenantAware\Actions\TenantCurrentOrLandlordAction;
 use Maize\TenantAware\Actions\TenantLandlordAction;
@@ -19,19 +17,25 @@ it('can get null actions', function () {
     expect(app(TenantCurrentOrLandlordAction::class)())->toBeNull();
 });
 
-it('can get only current tenant', function (Model|Builder $builder, bool $request, bool $result) {
+it('can get only current tenant', function (string $model, bool $asModel, bool $request, bool $result) {
+    $builder = $model::withoutGlobalScopes();
+
+    if ($asModel) {
+        $builder = $builder->getModel();
+    }
+
     if ($request) {
         request()->merge(['tenant.only_current' => null]);
     }
 
     expect(app(TenantOnlyCurrentAction::class)($builder))->toBe($result);
 })->with([
-    ['builder' => fn () => User::withoutGlobalScopes(), 'request' => true, 'result' => true],
-    ['builder' => fn () => User::withoutGlobalScopes(), 'request' => false, 'result' => true],
-    ['builder' => fn () => Article::withoutGlobalScopes(), 'request' => true, 'result' => true],
-    ['builder' => fn () => Article::withoutGlobalScopes(), 'request' => false, 'result' => false],
-    ['builder' => fn () => User::withoutGlobalScopes()->getModel(), 'request' => true, 'result' => true],
-    ['builder' => fn () => User::withoutGlobalScopes()->getModel(), 'request' => false, 'result' => true],
-    ['builder' => fn () => Article::withoutGlobalScopes()->getModel(), 'request' => true, 'result' => true],
-    ['builder' => fn () => Article::withoutGlobalScopes()->getModel(), 'request' => false, 'result' => false],
+    [User::class, false, true, true],
+    [User::class, false, false, true],
+    [Article::class, false, true, true],
+    [Article::class, false, false, false],
+    [User::class, true, true, true],
+    [User::class, true, false, true],
+    [Article::class, true, true, true],
+    [Article::class, true, false, false],
 ]);

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -43,9 +43,9 @@ it('can set tenant key on creating model', function (?Tenant $tenant) {
 
     expect($article->getTenantKey())->toBe($tenant?->getKey());
 })->with([
-    ['tenant' => fn () => $this->tenant],
-    ['tenant' => fn () => $this->landlord],
-    ['tenant' => null],
+    [fn () => $this->tenant],
+    [fn () => $this->landlord],
+    [null],
 ]);
 
 it('can set tenant key on model', function (Tenant|int|null $key, Tenant|int|null $result) {
@@ -69,6 +69,6 @@ it('can get tenant model', function (Tenant $tenant) {
 
     expect($article->tenant->getKey())->toBe($tenant->getKey());
 })->with([
-    ['tenant' => fn () => $this->tenant],
-    ['tenant' => fn () => $this->landlord],
+    [fn () => $this->tenant],
+    [fn () => $this->landlord],
 ]);

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -32,7 +32,9 @@ it('can get qualified tenant key name', function (string $key) {
     ['key' => 'tid'],
 ]);
 
-it('can set tenant key on creating model', function (?Tenant $tenant) {
+it('can set tenant key on creating model', function (?string $which) {
+    $tenant = $which ? $this->{$which} : null;
+
     $tenant?->makeCurrent();
 
     if (is_null($tenant)) {
@@ -43,32 +45,36 @@ it('can set tenant key on creating model', function (?Tenant $tenant) {
 
     expect($article->getTenantKey())->toBe($tenant?->getKey());
 })->with([
-    [fn () => $this->tenant],
-    [fn () => $this->landlord],
+    ['tenant'],
+    ['landlord'],
     [null],
 ]);
 
-it('can set tenant key on model', function (Tenant|int|null $key, Tenant|int|null $result) {
+it('can set tenant key on model', function (?string $which, bool $asKey) {
     $article = Article::factory()->create();
 
-    $article->setTenantKey($key);
+    $tenant = $which ? $this->{$which} : null;
 
-    expect($article->getTenantKey())->toBe($result);
+    $article->setTenantKey($asKey ? $tenant?->getKey() : $tenant);
+
+    expect($article->getTenantKey())->toBe($tenant?->getKey());
 })->with([
-    ['key' => fn () => $this->tenant, 'result' => fn () => $this->tenant->getKey()],
-    ['key' => fn () => $this->landlord, 'result' => fn () => $this->landlord->getKey()],
-    ['key' => fn () => $this->tenant->getKey(), 'result' => fn () => $this->tenant->getKey()],
-    ['key' => fn () => $this->landlord->getKey(), 'result' => fn () => $this->landlord->getKey()],
-    ['key' => null, 'result' => null],
+    ['tenant', false],
+    ['landlord', false],
+    ['tenant', true],
+    ['landlord', true],
+    [null, false],
 ]);
 
-it('can get tenant model', function (Tenant $tenant) {
+it('can get tenant model', function (string $which) {
+    $tenant = $this->{$which};
+
     $tenant->makeCurrent();
 
     $article = Article::factory()->create();
 
     expect($article->tenant->getKey())->toBe($tenant->getKey());
 })->with([
-    [fn () => $this->tenant],
-    [fn () => $this->landlord],
+    ['tenant'],
+    ['landlord'],
 ]);

--- a/tests/ScopeMethodTest.php
+++ b/tests/ScopeMethodTest.php
@@ -18,49 +18,49 @@ beforeEach(function () {
     $this->tenant->makeCurrent();
 });
 
-it('can apply scope tenant where', function (Tenant $current, ?Tenant $tenant = null, int $count = 0, int $articles = 1) {
-    $current->makeCurrent();
+it('can apply scope tenant where', function (string $current, ?string $tenant = null, int $count = 0, int $articles = 1) {
+    $this->{$current}->makeCurrent();
     Article::factory()->count($articles)->create();
 
     $models = app(ScopeTenantWhere::class)(
         Article::withoutGlobalScopes(),
-        $tenant
+        $tenant ? $this->{$tenant} : null
     )->get();
 
     expect($models->count())->toEqual($count);
 })->with([
-    [fn () => $this->tenant],
-    ['current' => fn () => $this->tenant, 'tenant' => fn () => $this->tenant, 'count' => 1],
-    ['current' => fn () => $this->tenant,  'tenant' => fn () => $this->landlord],
-    ['current' => fn () => $this->landlord, 'tenant' => fn () => $this->tenant],
-    ['current' => fn () => $this->landlord, 'tenant' => fn () => $this->landlord, 'count' => 1],
-    ['current' => fn () => $this->tenant, 'tenant' => fn () => $this->tenant, 'count' => 5, 'articles' => 5],
-    ['current' => fn () => $this->landlord, 'tenant' => fn () => $this->landlord, 'count' => 15, 'articles' => 15],
+    ['tenant'],
+    ['tenant', 'tenant', 1],
+    ['tenant', 'landlord'],
+    ['landlord', 'tenant'],
+    ['landlord', 'landlord', 1],
+    ['tenant', 'tenant', 5, 5],
+    ['landlord', 'landlord', 15, 15],
 ]);
 
-it('can apply scope or tenant where', function (string $condition, Tenant $current, ?Tenant $tenant = null, int $count = 0, int $articles = 1) {
-    $current->makeCurrent();
+it('can apply scope or tenant where', function (string $condition, string $current, ?string $tenant = null, int $count = 0, int $articles = 1) {
+    $this->{$current}->makeCurrent();
     Article::factory()->count($articles)->create();
 
     $models = app(ScopeOrTenantWhere::class)(
         Article::withoutGlobalScopes()->whereRaw($condition),
-        $tenant
+        $tenant ? $this->{$tenant} : null
     )->get();
 
     expect($models->count())->toEqual($count);
 })->with([
-    ['condition' => '1=0', 'current' => fn () => $this->tenant],
-    ['condition' => '1=1', 'current' => fn () => $this->tenant, 'tenant' => fn () => $this->tenant, 'count' => 1],
-    ['condition' => '1=0', 'current' => fn () => $this->tenant, 'tenant' => fn () => $this->tenant, 'count' => 1],
-    ['condition' => '1=1', 'current' => fn () => $this->tenant, 'tenant' => fn () => $this->tenant, 'count' => 1],
-    ['condition' => '1=0', 'current' => fn () => $this->tenant,  'tenant' => fn () => $this->landlord],
-    ['condition' => '1=1', 'current' => fn () => $this->tenant,  'tenant' => fn () => $this->landlord, 'count' => 1],
-    ['condition' => '1=0', 'current' => fn () => $this->landlord, 'tenant' => fn () => $this->tenant],
-    ['condition' => '1=1', 'current' => fn () => $this->landlord, 'tenant' => fn () => $this->tenant, 'count' => 1],
-    ['condition' => '1=0', 'current' => fn () => $this->landlord, 'tenant' => fn () => $this->landlord, 'count' => 1],
-    ['condition' => '1=1', 'current' => fn () => $this->landlord, 'tenant' => fn () => $this->landlord, 'count' => 1],
-    ['condition' => '1=0', 'current' => fn () => $this->tenant, 'tenant' => fn () => $this->tenant, 'count' => 5, 'articles' => 5],
-    ['condition' => '1=1', 'current' => fn () => $this->tenant, 'tenant' => fn () => $this->tenant, 'count' => 5, 'articles' => 5],
-    ['condition' => '1=0', 'current' => fn () => $this->landlord, 'tenant' => fn () => $this->landlord, 'count' => 15, 'articles' => 15],
-    ['condition' => '1=1', 'current' => fn () => $this->landlord, 'tenant' => fn () => $this->landlord, 'count' => 15, 'articles' => 15],
+    ['1=0', 'tenant'],
+    ['1=1', 'tenant', 'tenant', 1],
+    ['1=0', 'tenant', 'tenant', 1],
+    ['1=1', 'tenant', 'tenant', 1],
+    ['1=0', 'tenant', 'landlord'],
+    ['1=1', 'tenant', 'landlord', 1],
+    ['1=0', 'landlord', 'tenant'],
+    ['1=1', 'landlord', 'tenant', 1],
+    ['1=0', 'landlord', 'landlord', 1],
+    ['1=1', 'landlord', 'landlord', 1],
+    ['1=0', 'tenant', 'tenant', 5, 5],
+    ['1=1', 'tenant', 'tenant', 5, 5],
+    ['1=0', 'landlord', 'landlord', 15, 15],
+    ['1=1', 'landlord', 'landlord', 15, 15],
 ]);

--- a/tests/ScopeMethodTest.php
+++ b/tests/ScopeMethodTest.php
@@ -29,7 +29,7 @@ it('can apply scope tenant where', function (Tenant $current, ?Tenant $tenant = 
 
     expect($models->count())->toEqual($count);
 })->with([
-    ['current' => fn () => $this->tenant],
+    [fn () => $this->tenant],
     ['current' => fn () => $this->tenant, 'tenant' => fn () => $this->tenant, 'count' => 1],
     ['current' => fn () => $this->tenant,  'tenant' => fn () => $this->landlord],
     ['current' => fn () => $this->landlord, 'tenant' => fn () => $this->tenant],


### PR DESCRIPTION
## Summary

Adds **Laravel 13** support and drops **PHP 8.1**. Final support matrix: **Laravel 11 | 12 | 13** on **PHP 8.2+** (runtime), tested on **PHP 8.3 / 8.4**.

Dropping Laravel 10 is forced by the upgrade to **Pest 4**, whose `pest-plugin-laravel` no longer supports Laravel 10. Laravel 13 / Pest 4 / Testbench 11 all require PHP 8.3, so CI runs on 8.3/8.4 only while the runtime `require` stays at `^8.2` so L11/L12 consumers on 8.2 can still install.

## Changes

**Dependencies & CI**
- `composer.json`: `php: ^8.2`, `illuminate/*: ^11.0|^12.0|^13.0`, `spatie/laravel-package-tools: ^1.16.1`
- Dev toolchain: Pest 4, Larastan 3 / PHPStan 2, Testbench `^9.0|^10.0|^11.0`, phpstan deprecation/phpunit rules `^2.0`
- `run-tests.yml`: matrix `php: [8.4, 8.3]` × `laravel: [13, 12, 11]` with testbench 9/10/11 mapping; removed the obsolete `exclude` block
- `phpstan.yml`: PHP `8.3`

**Fixes required by the upgrade**
- `ScopeOrTenantWhere`: fixed lowercase `: builder` return type, now caught by PHPStan 2 (`class.nameCase`)
- `phpstan.neon.dist`: removed `checkMissingIterableValueType` (removed in PHPStan 2)
- `phpstan-baseline.neon`: baselined the package-trait `trait.unused` false positive on `BelongsToTenant`
- `tests/`: adapted single-argument bound datasets to Pest 4 (closures in single-key datasets are no longer resolved; switched to numeric keys)
- Pint reformatting on `config/tenant-aware.php` and `BelongsToTenant.php` (updated default rules)

The CHANGELOG is intentionally left untouched.

## Verification

Run locally with PHP 8.4:
- ✅ Tests: **51 passed** on Laravel 13.15 **and** Laravel 11
- ✅ PHPStan: no errors
- ✅ Pint: passed
- ✅ `composer validate`: valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)